### PR TITLE
Linux permissions correction to php image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,6 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 && ln -s /usr/local/bin/wp-cli.phar /usr/local/bin/wp
 
 # Run this container as "webuser"
-RUN groupadd -r webuser && useradd -r -g webuser webuser
+RUN groupadd -r -g 1000 webuser && useradd -r -u 1000 -g webuser webuser
 RUN usermod -aG www-data webuser
 USER webuser


### PR DESCRIPTION
Cross tested this on the testing Mac using VRT and all of the ACF saves generate files and the site loads and responds as expected. The permissions changes don't affect mac/windows because they push files over a shared drive connection and ignore permissions.